### PR TITLE
jamovi bug fix, TOSTpaired bug fix, & TOSTmeta adjustment

### DIFF
--- a/R/TOSTmeta.R
+++ b/R/TOSTmeta.R
@@ -16,7 +16,7 @@
 #' @section References:
 #' Rogers, J. L., Howard, K. I., & Vessey, J. T. (1993). Using significance tests to evaluate equivalence between two experimental groups. Psychological Bulletin, 113(3), 553, formula page 557.
 #' @export
-#' 
+#'
 
 
 TOSTmeta<-function(ES,var,se,low_eqbound_d, high_eqbound_d, alpha){
@@ -34,10 +34,10 @@ TOSTmeta<-function(ES,var,se,low_eqbound_d, high_eqbound_d, alpha){
       stop("Need to specify variance (var) or standard error (se).")
     }
   }
-  Z1<-(ES+high_eqbound_d)/se
-  p1<-pnorm(Z1, lower.tail=FALSE) 
-  Z2<-(ES+low_eqbound_d)/se
-  p2<-pnorm(Z2, lower.tail=TRUE) 
+  Z1<-(ES-low_eqbound_d)/se
+  p1<-pnorm(Z1, lower.tail=FALSE)
+  Z2<-(ES-high_eqbound_d)/se
+  p2<-pnorm(Z2, lower.tail=TRUE)
   Z<-(ES/se)
   pttest<-pnorm(-abs(Z))
   LL90<-ES-qnorm(1-alpha)*(se)
@@ -68,10 +68,10 @@ TOSTmeta<-function(ES,var,se,low_eqbound_d, high_eqbound_d, alpha){
   CIresults<-data.frame(LL90,UL90)
   colnames(CIresults) <- c(paste("Lower Limit ",100*(1-alpha*2),"% CI",sep=""),paste("Upper Limit ",100*(1-alpha*2),"% CI",sep=""))
   cat("TOST results:\n")
-  print(TOSTresults)  
+  print(TOSTresults)
   cat("\n")
   cat("Equivalence bounds (Cohen's d):\n")
-  print(bound_d_results)  
+  print(bound_d_results)
   cat("\n")
   cat("TOST confidence interval:\n")
   print(CIresults)

--- a/R/TOSTpaired.R
+++ b/R/TOSTpaired.R
@@ -19,12 +19,12 @@
 #' @importFrom stats pnorm pt qnorm qt
 #' @importFrom graphics abline plot points segments title
 #' @export
-#' 
+#'
 
 TOSTpaired<-function(n,m1,m2,sd1,sd2,r12,low_eqbound_dz, high_eqbound_dz, alpha){
   if(missing(alpha)) {
     alpha <- 0.05
-  }  
+  }
   sdif<-sqrt(sd1^2+sd2^2-2*r12*sd1*sd2)
   low_eqbound<-low_eqbound_dz*sdif
   high_eqbound<-high_eqbound_dz*sdif
@@ -32,10 +32,10 @@ TOSTpaired<-function(n,m1,m2,sd1,sd2,r12,low_eqbound_dz, high_eqbound_dz, alpha)
   t<-(m1-m2)/se
   degree_f<-n-1
   pttest<-2*pt(abs(t), degree_f, lower.tail=FALSE)
-  t1<-((m1-m2)+(low_eqbound_dz*sdif))/se
-  p1<-1-pt(t1, degree_f, lower.tail=FALSE)
-  t2<-((m1-m2)+(high_eqbound_dz*sdif))/se
-  p2<-pt(t2, degree_f, lower.tail=FALSE)
+  t1<-((m1-m2)-(low_eqbound_dz*sdif))/se
+  p1<-pt(t1, degree_f, lower.tail=FALSE)
+  t2<-((m1-m2)-(high_eqbound_dz*sdif))/se
+  p2<-pt(t2, degree_f, lower.tail=TRUE)
   ttost<-ifelse(abs(t1) < abs(t2), t1, t2)
   LL90<-((m1-m2)-qt(1-alpha, degree_f)*se)
   UL90<-((m1-m2)+qt(1-alpha, degree_f)*se)
@@ -67,13 +67,13 @@ TOSTpaired<-function(n,m1,m2,sd1,sd2,r12,low_eqbound_dz, high_eqbound_dz, alpha)
   CIresults<-data.frame(LL90,UL90)
   colnames(CIresults) <- c(paste("Lower Limit ",100*(1-alpha*2),"% CI raw",sep=""),paste("Upper Limit ",100*(1-alpha*2),"% CI raw",sep=""))
   cat("TOST results:\n")
-  print(TOSTresults)  
+  print(TOSTresults)
   cat("\n")
   cat("Equivalence bounds (Cohen's dz):\n")
-  print(bound_dz_results)  
+  print(bound_dz_results)
   cat("\n")
   cat("Equivalence bounds (raw scores):\n")
-  print(bound_results)  
+  print(bound_results)
   cat("\n")
   cat("TOST confidence interval:\n")
   print(CIresults)

--- a/R/TOSTpaired.raw.R
+++ b/R/TOSTpaired.raw.R
@@ -11,7 +11,7 @@
 #' @return Returns TOST t-value 1, TOST p-value 1, TOST t-value 2, TOST p-value 2, degrees of freedom, low equivalence bound, high equivalence bound, Lower limit confidence interval TOST, Upper limit confidence interval TOST
 #' @examples
 #' ## Test means of 5.83 and 5.75, standard deviations of 1.17 and 1.30 in sample of 65 pairs
-#' ## with correlation between observations of 0.745 using equivalence bounds in raw units of 
+#' ## with correlation between observations of 0.745 using equivalence bounds in raw units of
 #' ## -0.34 and 0.34, (with default alpha setting of = 0.05).
 #' TOSTpaired.raw(n=65,m1=5.83,m2=5.75,sd1=1.17,sd2=1.30,r12=0.745,low_eqbound=-0.34,high_eqbound=0.34)
 #' @section References:
@@ -19,21 +19,21 @@
 #' @importFrom stats pnorm pt qnorm qt
 #' @importFrom graphics abline plot points segments title
 #' @export
-#' 
+#'
 
 TOSTpaired.raw<-function(n,m1,m2,sd1,sd2,r12,low_eqbound, high_eqbound, alpha){
   if(missing(alpha)) {
     alpha <- 0.05
-  }  
+  }
   sdif<-sqrt(sd1^2+sd2^2-2*r12*sd1*sd2)
   se<-sdif/sqrt(n)
   t<-(m1-m2)/se
   degree_f<-n-1
   pttest<-2*pt(abs(t), degree_f, lower.tail=FALSE)
-  t1<-((m1-m2)+(low_eqbound))/se
-  p1<-1-pt(t1, degree_f, lower.tail=FALSE)
-  t2<-((m1-m2)+(high_eqbound))/se
-  p2<-pt(t2, degree_f, lower.tail=FALSE)
+  t1<-((m1-m2)-(low_eqbound_dz*sdif))/se
+  p1<-pt(t1, degree_f, lower.tail=FALSE)
+  t2<-((m1-m2)-(high_eqbound_dz*sdif))/se
+  p2<-pt(t2, degree_f, lower.tail=TRUE)
   ttost<-ifelse(abs(t1) < abs(t2), t1, t2)
   LL90<-((m1-m2)-qt(1-alpha, degree_f)*se)
   UL90<-((m1-m2)+qt(1-alpha, degree_f)*se)
@@ -61,10 +61,10 @@ TOSTpaired.raw<-function(n,m1,m2,sd1,sd2,r12,low_eqbound, high_eqbound, alpha){
   CIresults<-data.frame(LL90,UL90)
   colnames(CIresults) <- c(paste("Lower Limit ",100*(1-alpha*2),"% CI raw",sep=""),paste("Upper Limit ",100*(1-alpha*2),"% CI raw",sep=""))
   cat("TOST results:\n")
-  print(TOSTresults)  
+  print(TOSTresults)
   cat("\n")
   cat("Equivalence bounds (raw scores):\n")
-  print(bound_results)  
+  print(bound_results)
   cat("\n")
   cat("TOST confidence interval:\n")
   print(CIresults)

--- a/R/datatostone.h.R
+++ b/R/datatostone.h.R
@@ -21,7 +21,7 @@ dataTOSToneOptions <- R6::R6Class(
                 name='dataTOSTone',
                 requiresData=TRUE,
                 ...)
-        
+
             private$..vars <- jmvcore::OptionVariables$new(
                 "vars",
                 vars,
@@ -57,7 +57,7 @@ dataTOSToneOptions <- R6::R6Class(
                 "plots",
                 plots,
                 default=FALSE)
-        
+
             self$.addOption(private$..vars)
             self$.addOption(private$..mu)
             self$.addOption(private$..low_eqbound_d)
@@ -118,11 +118,11 @@ dataTOSToneResults <- R6::R6Class(
                     list(`name`="t[0]", `title`="t", `type`="number"),
                     list(`name`="df[0]", `title`="df", `type`="integer"),
                     list(`name`="p[0]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Upper"),
+                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Lower"),
                     list(`name`="t[1]", `title`="t", `type`="number"),
                     list(`name`="df[1]", `title`="df", `type`="integer"),
                     list(`name`="p[1]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Lower"),
+                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Upper"),
                     list(`name`="t[2]", `title`="t", `type`="number"),
                     list(`name`="df[2]", `title`="df", `type`="integer"),
                     list(`name`="p[2]", `title`="p", `type`="number", `format`="zto,pvalue")))
@@ -212,23 +212,23 @@ dataTOSToneBase <- R6::R6Class(
 #'
 #' @examples
 #' library("TOSTER")
-#' 
+#'
 #' dataTOSTone(data = iris, vars = "Sepal.Width", mu = 3, low_eqbound_d = -0.3, high_eqbound_d = 0.3,
 #'             alpha = 0.05, desc = TRUE, plots = TRUE)
-#' 
+#'
 #' TOSTone(m=3.05733,mu=3,sd=0.4358663,n=150,low_eqbound_d=-0.3, high_eqbound_d=0.3, alpha=0.05)
-#' 
+#'
 #' @param data the data as a data frame
 #' @param vars a vector of strings naming variables of interest in \code{data}
-#' @param mu a number (default: 0) to compare against 
-#' @param low_eqbound_d lower equivalence bounds (e.g., -0.5) expressed in 
-#'   standardized mean difference (Cohen's d) 
-#' @param high_eqbound_d upper equivalence bounds (e.g., 0.5) expressed in 
-#'   standardized mean difference (Cohen's d) 
+#' @param mu a number (default: 0) to compare against
+#' @param low_eqbound_d lower equivalence bounds (e.g., -0.5) expressed in
+#'   standardized mean difference (Cohen's d)
+#' @param high_eqbound_d upper equivalence bounds (e.g., 0.5) expressed in
+#'   standardized mean difference (Cohen's d)
 #' @param alpha alpha level (default = 0.05)
-#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive 
-#'   statistics 
-#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots 
+#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive
+#'   statistics
+#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots
 #' @export
 dataTOSTone <- function(
     data,

--- a/R/datatostpaired.b.R
+++ b/R/datatostpaired.b.R
@@ -72,10 +72,10 @@ dataTOSTpairedClass <- R6::R6Class(
         t<-(m1-m2)/se
         degree_f<-n-1
         pttest<-2*pt(abs(t), degree_f, lower.tail=FALSE)
-        t1<-((m1-m2)+(low_eqbound_dz*sdif))/se
-        p1<-1-pt(t1, degree_f, lower.tail=FALSE)
-        t2<-((m1-m2)+(high_eqbound_dz*sdif))/se
-        p2<-pt(t2, degree_f, lower.tail=FALSE)
+        t1<-((m1-m2)-(low_eqbound_dz*sdif))/se
+        p1<-pt(t1, degree_f, lower.tail=FALSE)
+        t2<-((m1-m2)-(high_eqbound_dz*sdif))/se
+        p2<-pt(t2, degree_f, lower.tail=TRUE)
         ttost<-ifelse(abs(t1) < abs(t2), t1, t2)
         LL90<-((m1-m2)-qt(1-alpha, degree_f)*se)
         UL90<-((m1-m2)+qt(1-alpha, degree_f)*se)

--- a/R/datatostpaired.h.R
+++ b/R/datatostpaired.h.R
@@ -20,7 +20,7 @@ dataTOSTpairedOptions <- R6::R6Class(
                 name='dataTOSTpaired',
                 requiresData=TRUE,
                 ...)
-        
+
             private$..pairs <- jmvcore::OptionPairs$new(
                 "pairs",
                 pairs,
@@ -52,7 +52,7 @@ dataTOSTpairedOptions <- R6::R6Class(
                 "plots",
                 plots,
                 default=FALSE)
-        
+
             self$.addOption(private$..pairs)
             self$.addOption(private$..low_eqbound_dz)
             self$.addOption(private$..high_eqbound_dz)
@@ -109,11 +109,11 @@ dataTOSTpairedResults <- R6::R6Class(
                     list(`name`="t[0]", `title`="t", `type`="number"),
                     list(`name`="df[0]", `title`="df", `type`="integer"),
                     list(`name`="p[0]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Upper"),
+                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Lower"),
                     list(`name`="t[1]", `title`="t", `type`="number"),
                     list(`name`="df[1]", `title`="df", `type`="integer"),
                     list(`name`="p[1]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Lower"),
+                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Upper"),
                     list(`name`="t[2]", `title`="t", `type`="number"),
                     list(`name`="df[2]", `title`="df", `type`="integer"),
                     list(`name`="p[2]", `title`="p", `type`="number", `format`="zto,pvalue")))
@@ -206,24 +206,24 @@ dataTOSTpairedBase <- R6::R6Class(
 #'
 #' @examples
 #' library("TOSTER")
-#' 
+#'
 #' dataTOSTpaired(data = randu, pairs = list(c(i1="x",i2="y")), low_eqbound_dz = -0.3,
 #'                high_eqbound_dz = 0.3, alpha = 0.05, desc = TRUE, plots = TRUE)
-#' 
+#'
 #' @section References:
 #' Mara, C. A., & Cribbie, R. A. (2012). Paired-Samples Tests of Equivalence. Communications in Statistics - Simulation and Computation, 41(10), 1928-1943. https://doi.org/10.1080/03610918.2011.626545, formula page 1932. Note there is a typo in the formula: n-1 should be n (personal communication, 31-08-2016)
 #'
 #' @param data the data as a data frame
-#' @param pairs a list of vectors of strings naming variables to pair from 
+#' @param pairs a list of vectors of strings naming variables to pair from
 #'   \code{data}
-#' @param low_eqbound_dz lower equivalence bounds (e.g., -0.5) expressed in 
-#'   standardized mean difference (Cohen's dz) 
-#' @param high_eqbound_dz upper equivalence bounds (e.g., 0.5) expressed in 
-#'   standardized mean difference (Cohen's dz) 
+#' @param low_eqbound_dz lower equivalence bounds (e.g., -0.5) expressed in
+#'   standardized mean difference (Cohen's dz)
+#' @param high_eqbound_dz upper equivalence bounds (e.g., 0.5) expressed in
+#'   standardized mean difference (Cohen's dz)
 #' @param alpha alpha level (default = 0.05)
-#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive 
-#'   statistics 
-#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots 
+#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive
+#'   statistics
+#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots
 #' @export
 dataTOSTpaired <- function(
     data,

--- a/R/datatostr.h.R
+++ b/R/datatostr.h.R
@@ -20,7 +20,7 @@ dataTOSTrOptions <- R6::R6Class(
                 name='dataTOSTr',
                 requiresData=TRUE,
                 ...)
-        
+
             private$..pairs <- jmvcore::OptionPairs$new(
                 "pairs",
                 pairs,
@@ -52,7 +52,7 @@ dataTOSTrOptions <- R6::R6Class(
                 "plots",
                 plots,
                 default=FALSE)
-        
+
             self$.addOption(private$..pairs)
             self$.addOption(private$..low_eqbound_r)
             self$.addOption(private$..high_eqbound_r)
@@ -108,10 +108,10 @@ dataTOSTrResults <- R6::R6Class(
                     list(`name`="b[0]", `title`="", `type`="text", `content`="Pearson's r"),
                     list(`name`="r[0]", `title`="r", `type`="number"),
                     list(`name`="p[0]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Upper"),
+                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Lower"),
                     list(`name`="r[1]", `title`="r", `type`="number"),
                     list(`name`="p[1]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Lower"),
+                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Upper"),
                     list(`name`="r[2]", `title`="r", `type`="number"),
                     list(`name`="p[2]", `title`="p", `type`="number", `format`="zto,pvalue")))
             private$..eqb <- jmvcore::Table$new(
@@ -193,18 +193,18 @@ dataTOSTrBase <- R6::R6Class(
 
 #' TOST Correlation
 #'
-#' 
+#'
 #' @param data the data as a data frame
-#' @param pairs a list of vectors of strings naming variables to correlate 
-#'   from \code{data} 
-#' @param low_eqbound_r lower equivalence bounds (e.g., -0.3) expressed in a 
-#'   correlation effect size 
-#' @param high_eqbound_r upper equivalence bounds (e.g., 0.3) expressed in a 
-#'   correlation effect size 
+#' @param pairs a list of vectors of strings naming variables to correlate
+#'   from \code{data}
+#' @param low_eqbound_r lower equivalence bounds (e.g., -0.3) expressed in a
+#'   correlation effect size
+#' @param high_eqbound_r upper equivalence bounds (e.g., 0.3) expressed in a
+#'   correlation effect size
 #' @param alpha alpha level (default = 0.05)
-#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive 
-#'   statistics 
-#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots 
+#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive
+#'   statistics
+#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots
 #' @export
 dataTOSTr <- function(
     data,

--- a/R/datatosttwo.h.R
+++ b/R/datatosttwo.h.R
@@ -22,7 +22,7 @@ dataTOSTtwoOptions <- R6::R6Class(
                 name='dataTOSTtwo',
                 requiresData=TRUE,
                 ...)
-        
+
             private$..deps <- jmvcore::OptionVariables$new(
                 "deps",
                 deps,
@@ -62,7 +62,7 @@ dataTOSTtwoOptions <- R6::R6Class(
                 "plots",
                 plots,
                 default=FALSE)
-        
+
             self$.addOption(private$..deps)
             self$.addOption(private$..group)
             self$.addOption(private$..var_equal)
@@ -126,11 +126,11 @@ dataTOSTtwoResults <- R6::R6Class(
                     list(`name`="t[0]", `title`="t", `type`="number"),
                     list(`name`="df[0]", `title`="df", `type`="number"),
                     list(`name`="p[0]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Upper"),
+                    list(`name`="b[1]", `title`="", `type`="text", `content`="TOST Lower"),
                     list(`name`="t[1]", `title`="t", `type`="number"),
                     list(`name`="df[1]", `title`="df", `type`="number"),
                     list(`name`="p[1]", `title`="p", `type`="number", `format`="zto,pvalue"),
-                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Lower"),
+                    list(`name`="b[2]", `title`="", `type`="text", `content`="TOST Upper"),
                     list(`name`="t[2]", `title`="t", `type`="number"),
                     list(`name`="df[2]", `title`="df", `type`="number"),
                     list(`name`="p[2]", `title`="p", `type`="number", `format`="zto,pvalue")))
@@ -227,16 +227,16 @@ dataTOSTtwoBase <- R6::R6Class(
 #'
 #' @examples
 #' library(TOSTER)
-#' 
+#'
 #' ## Load iris dataset, remove one of the three groups so two are left
-#' 
+#'
 #' data<-iris[which(iris$Species!="versicolor"),]
-#' 
+#'
 #' ## TOST procedure on the raw data
-#' 
+#'
 #' dataTOSTtwo(data, deps="Sepal.Width", group="Species", var_equal = TRUE, low_eqbound_d = -0.5,
 #'             high_eqbound_d = 0.5, alpha = 0.05, desc = TRUE, plots = TRUE)
-#' 
+#'
 #' @section References:
 #' Berger, R. L., & Hsu, J. C. (1996). Bioequivalence Trials, Intersection-Union Tests and Equivalence Confidence Sets. Statistical Science, 11(4), 283-302.
 #'
@@ -244,18 +244,18 @@ dataTOSTtwoBase <- R6::R6Class(
 #'
 #' @param data the data as a data frame
 #' @param deps a vector of strings naming dependent variables in \code{data}
-#' @param group a string naming the grouping variable in \code{data}; must 
-#'   have two levels 
-#' @param var_equal \code{TRUE} or \code{FALSE} (default), assume equal 
-#'   variances 
-#' @param low_eqbound_d lower equivalence bounds (e.g., -0.5) expressed in 
-#'   standardized mean difference (Cohen's d) 
-#' @param high_eqbound_d upper equivalence bounds (e.g., 0.5) expressed in 
-#'   standardized mean difference (Cohen's d) 
+#' @param group a string naming the grouping variable in \code{data}; must
+#'   have two levels
+#' @param var_equal \code{TRUE} or \code{FALSE} (default), assume equal
+#'   variances
+#' @param low_eqbound_d lower equivalence bounds (e.g., -0.5) expressed in
+#'   standardized mean difference (Cohen's d)
+#' @param high_eqbound_d upper equivalence bounds (e.g., 0.5) expressed in
+#'   standardized mean difference (Cohen's d)
 #' @param alpha alpha level (default = 0.05)
-#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive 
-#'   statistics 
-#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots 
+#' @param desc \code{TRUE} or \code{FALSE} (default), provide descriptive
+#'   statistics
+#' @param plots \code{TRUE} or \code{FALSE} (default), provide plots
 #' @export
 dataTOSTtwo <- function(
     data,


### PR DESCRIPTION
1) Bug fix: TOST output in jamovi had switched labels for lower and upper bound. I believe the bug was in the .h.R files, which I fixed accordingly for all four functions (dataTOSTone, dataTOSTpaired, dataTOSTr, dataTOSTtwo).

2) Bug fix for TOSTpaired.R, TOSTpaired.raw.R, and datatostpaired.b.R: Bug led to switched p-values for lower and upper equivalence bounds.
I changed
  t1<-((m1-m2)+(low_eqbound_dz*sdif))/se
  p1<-1-pt(t1, degree_f, lower.tail=FALSE)
  t2<-((m1-m2)+(high_eqbound_dz*sdif))/se
  p2<-pt(t2, degree_f, lower.tail=FALSE)
to
  t1<-((m1-m2)-(low_eqbound_dz*sdif))/se
  p1<-pt(t1, degree_f, lower.tail=FALSE)
  t2<-((m1-m2)-(high_eqbound_dz*sdif))/se
  p2<-pt(t2, degree_f, lower.tail=TRUE)

3) Slight adjustment for TOSTmeta.R: I changed
  Z1<-(ES+high_eqbound_d)/se
  Z2<-(ES+low_eqbound_d)/se
to
  Z1<-(ES-low_eqbound_d)/se
  Z2<-(ES-high_eqbound_d)/se
Because this is the way all other TOST functions are set up. The results are identical.