### PR TITLE
simple_htest defaults

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,11 @@ NEWS
 # TOSTER v0.8.3
 - Change in the standard error formulation to Glass delta for independent samples
   - Hat tip to Paul Dudgeon for catching an error in the code that led to this development
+  - Other small changes to standard error calcs (see vignettes for details)
 - Small modification to `plot_smd` to catch errors when attempting to plot
-- Fixed notation for Brunner-Munzel test
+- Brunner-Munzel updates
+  - Added more warning messages
+  - Changed default for `simple_htest` to 0.5 rather than 0
 
 # TOSTER v0.8.2
 

--- a/R/brunner_munzel.R
+++ b/R/brunner_munzel.R
@@ -97,6 +97,11 @@ brunner_munzel.default = function(x,
     ( mu < 0 || mu > 1))
     stop("'mu' must be a single number between 0 and 1.")
 
+  if(alternative == "two.sided"){
+    if(mu == 0 | mu == 1){
+      stop("'mu' cannot be 0 or 1 when alternative is 'two.sided'")
+    }
+  }
   if(!is.numeric(x)) stop("'x' must be numeric")
   if(!missing(y)) {
     if(!is.numeric(y)) stop("'y' must be numeric")

--- a/R/brunner_munzel.R
+++ b/R/brunner_munzel.R
@@ -351,7 +351,12 @@ brunner_munzel.default = function(x,
   }
 
   names(mu) <- "relative effect"
-  names(test_stat) = "t"
+  if(perm){
+    names(test_stat) = "t-observed"
+  } else {
+    names(test_stat) = "t"
+  }
+
   names(df.sw) = "df"
   cint = c(pd.lower,pd.upper)
   attr(cint,"conf.level") = ifelse(alternative == "two.sided",

--- a/R/simple_htest.R
+++ b/R/simple_htest.R
@@ -78,8 +78,10 @@ simple_htest.default = function(x,
  if(is.null(mu)){
    if(test == "brunner_munzel"){
      mu = 0.5
+     message(paste0("mu set to ", mu))
    } else{
      mu = 0
+     message(paste0("mu set to ", mu))
    }
  }
 

--- a/R/simple_htest.R
+++ b/R/simple_htest.R
@@ -51,7 +51,7 @@ simple_htest <- function(x, ...,
                                          "greater",
                                          "equivalence",
                                          "minimal.effect"),
-                         mu = 0,
+                         mu = NULL,
                          alpha = 0.05){
   UseMethod("simple_htest")
 }
@@ -70,11 +70,18 @@ simple_htest.default = function(x,
                                                 "greater",
                                                 "equivalence",
                                                 "minimal.effect"),
-                                mu = 0,
+                                mu = NULL,
                                 alpha = 0.05,
                                 ...) {
  alternative = match.arg(alternative)
  test = match.arg(test)
+ if(is.null(mu)){
+   if(test == "brunner_munzel"){
+     mu = 0.5
+   } else{
+     mu = 0
+   }
+ }
 
  if(alternative %in% c("equivalence","minimal.effect")){
 

--- a/man/simple_htest.Rd
+++ b/man/simple_htest.Rd
@@ -11,7 +11,7 @@ simple_htest(
   ...,
   paired = FALSE,
   alternative = c("two.sided", "less", "greater", "equivalence", "minimal.effect"),
-  mu = 0,
+  mu = NULL,
   alpha = 0.05
 )
 
@@ -21,7 +21,7 @@ simple_htest(
   test = c("t.test", "wilcox.test", "brunner_munzel"),
   paired = FALSE,
   alternative = c("two.sided", "less", "greater", "equivalence", "minimal.effect"),
-  mu = 0,
+  mu = NULL,
   alpha = 0.05,
   ...
 )


### PR DESCRIPTION
- add defaults for simple_htest that differ from t.test to brunner_munzel (0 vs 0.5)

- add more warning messages for `brunner_munzel` and limits to the `mu` argument